### PR TITLE
Adiciona carrossel de marcas na home

### DIFF
--- a/content/home.json
+++ b/content/home.json
@@ -148,6 +148,13 @@
       "title": "Arquivos"
     },
     {
+      "type": "brands-carousel",
+      "sort": "",
+      "limit": 24,
+      "offset": 0,
+      "autoplay": 3000
+    },
+    {
       "type": "newsletter-mt",
       "active": true
     }


### PR DESCRIPTION
## Resumo
- Adiciona a seção `brands-carousel` (widget já usado na página de marcas) em `content/home.json`, logo acima do newsletter.
- `sort: ""` (ordem padrão), `limit: 24`, `autoplay: 3000`ms — ajustável.

## Importante antes de mergear
O carrossel só exibe logos de marcas que já tenham `logo` cadastrada em **Produtos > Marcas** no painel admin. Sem marcas cadastradas com logo, a seção fica vazia (não quebra a página, só não renderiza nada útil). Recomendo cadastrar as marcas antes ou logo após o merge.

## Test plan
- [ ] Cadastrar ao menos algumas marcas com logo em Produtos > Marcas
- [ ] Rodar `npm run serve` local ou revisar preview de deploy e conferir a home
- [ ] Ajustar posição/limite/autoplay se necessário

🤖 Generated with [Claude Code](https://claude.com/claude-code)